### PR TITLE
IOS端末でアプリがフォアグラウンド時に通知音を鳴らせる

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -32,6 +32,8 @@ PODS:
     - GoogleUtilities/UserDefaults (~> 7.8)
     - nanopb (< 2.30911.0, >= 2.30908.0)
   - Flutter (1.0.0)
+  - flutter_local_notifications (0.0.1):
+    - Flutter
   - GoogleDataTransport (9.4.1):
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30911.0, >= 2.30908.0)
@@ -77,6 +79,7 @@ DEPENDENCIES:
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
   - Flutter (from `Flutter`)
+  - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
 
@@ -99,6 +102,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_messaging/ios"
   Flutter:
     :path: Flutter
+  flutter_local_notifications:
+    :path: ".symlinks/plugins/flutter_local_notifications/ios"
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
   shared_preferences_foundation:
@@ -113,6 +118,7 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 8f581fca6478a50705d2bd2abd66d306e0f5736e
   FirebaseMessaging: 4d52717dd820707cc4eadec5eb981b4832ec8d5d
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  flutter_local_notifications: 4cde75091f6327eb8517fa068a0a5950212d2086
   GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
   GoogleUtilities: d053d902a8edaa9904e1bd00c37535385b8ed152
   nanopb: 438bc412db1928dac798aa6fd75726007be04262

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,10 +1,13 @@
 import UIKit
 import Flutter
 import FirebaseCore
+import FirebaseMessaging
 import UserNotifications
-// TODO: IOSローカル通知を受け取った際にFirebaseMessaging.onMessage.listenが無効になる
+
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
+  private let channel = "com.example.app/notifications"
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -12,24 +15,50 @@ import UserNotifications
     FirebaseApp.configure()
     GeneratedPluginRegistrant.register(with: self)
 
-    // 通知の許可をリクエスト
     UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { (granted, error) in
       if granted {
-        UNUserNotificationCenter.current().delegate = self
+        DispatchQueue.main.async {
+          application.registerForRemoteNotifications()
+        }
       }
     }
-    application.registerForRemoteNotifications()
+
+    UNUserNotificationCenter.current().delegate = self
 
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 
-    // 通知を受け取ったときの処理
-    override func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-      completionHandler([.alert, .sound, .badge])
-    }
+  override func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+    Messaging.messaging().apnsToken = deviceToken
+  }
 
-    // 通知をタップしたときの処理
-    override func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-      completionHandler()
+  // 通知を受け取った際に通知音を鳴らし、Flutterにメッセージを送る
+  override func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+    let userInfo = notification.request.content.userInfo
+    if let aps = userInfo["aps"] as? [String: AnyObject], let alert = aps["alert"] as? [String: AnyObject] {
+      let title = alert["title"] as? String
+      let body = alert["body"] as? String
+
+      // Flutterにメッセージを送る
+      let flutterViewController = window?.rootViewController as! FlutterViewController
+      let channel = FlutterMethodChannel(name: self.channel, binaryMessenger: flutterViewController.binaryMessenger)
+      channel.invokeMethod("onMessage", arguments: ["title": title, "body": body])
     }
+    completionHandler([.alert, .sound])
+  }
+
+  // 通知をタップした際の処理
+  override func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+    let userInfo = response.notification.request.content.userInfo
+    if let aps = userInfo["aps"] as? [String: AnyObject], let alert = aps["alert"] as? [String: AnyObject] {
+      let title = alert["title"] as? String
+      let body = alert["body"] as? String
+
+      // Flutterにメッセージを送る
+      let flutterViewController = window?.rootViewController as! FlutterViewController
+      let channel = FlutterMethodChannel(name: self.channel, binaryMessenger: flutterViewController.binaryMessenger)
+      channel.invokeMethod("onNotificationTap", arguments: ["title": title, "body": body])
+    }
+    completionHandler()
+  }
 }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,6 +1,7 @@
 import UIKit
 import Flutter
 import FirebaseCore
+import UserNotifications
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
@@ -10,6 +11,56 @@ import FirebaseCore
   ) -> Bool {
     FirebaseApp.configure()
     GeneratedPluginRegistrant.register(with: self)
+
+    let center = UNUserNotificationCenter.current()
+    center.delegate = self
+
+    center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+        if let error = error {
+            print("通知の権限リクエストでエラーが発生しました: \(error)")
+        }
+    }
+
+    // MethodChannelの設定
+    let controller: FlutterViewController = window?.rootViewController as! FlutterViewController
+    let channel = FlutterMethodChannel(name: "com.yourcompany.notifications",
+                                       binaryMessenger: controller.binaryMessenger)
+
+    channel.setMethodCallHandler { [weak self] (call: FlutterMethodCall, result: @escaping FlutterResult) in
+        if call.method == "triggerNotification" {
+            self?.triggerNotification()
+            result(nil)
+        } else {
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  // フォアグラウンドで通知を受け取った時に呼ばれるデリゲートメソッド
+  override func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    willPresent notification: UNNotification,
+    withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+  ) {
+    // 通知バナー表示、通知音の再生を指定
+    completionHandler([.alert, .sound])
+  }
+
+  // 通知をトリガーするメソッド
+  @objc func triggerNotification() {
+    let content = UNMutableNotificationContent()
+    content.title = "新しいメッセージがあります"
+    content.body = "あなたに新しいメッセージが届きました"
+    content.sound = UNNotificationSound.default
+
+    let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
+
+    UNUserNotificationCenter.current().add(request) { error in
+        if let error = error {
+            print("通知のトリガーに失敗しました: \(error)")
+        }
+    }
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,12 +21,12 @@ import 'firebase_options.dart';
 @pragma('vm:entry-point')
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   await Firebase.initializeApp();
-  print("Handling a background message: ${message.messageId}");
+  print("(IOS)バックグラウンド時に通知が届きました。: ${message.messageId}");
   await NotificationPreferencesManager.init();
   await NotificationPreferencesManager.setNewNotificationsForBackground(true);
   await NotificationPreferencesManager.setNotificationCountAddForBackground();
-  print('notificationCount: ${NotificationPreferencesManager.getNotificationCount()}');
-  print('hasNewNotifications: ${NotificationPreferencesManager.getNewNotifications()}');
+  // print('notificationCount: ${NotificationPreferencesManager.getNotificationCount()}');
+  // print('hasNewNotifications: ${NotificationPreferencesManager.getNewNotifications()}');
   print("完了: ${message.messageId}");
 }
 
@@ -41,39 +41,12 @@ void main() async {
   //
   await NotificationPreferencesManager.init();
   // await SharedPreferencesService.clearSharedPreferences(); // 開発用
-  final container = ProviderContainer();
   FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
   setupTokenRefreshListener();
 
-  // ④
-  // アプリがフォアグラウンド状態にある場合にメッセージを受け取る処理
-  //
-  FirebaseMessaging.onMessage.listen((RemoteMessage message) async {
-    print('Got a message whilst in the foreground!');
-    print('Message data: ${message.data}');
-    await NotificationPreferencesManager.setNewNotifications(container,true);
-    await NotificationPreferencesManager.setNotificationCountAdd(container);
-    const MethodChannel channel = MethodChannel('com.yourcompany.notifications');
-
-    // ⑤
-    // IOSとAndroidの場合で通知音を再生する処理を分ける
-    //
-    if (Platform.isIOS) {
-      // TODO: IOSローカル通知を受け取った際にFirebaseMessaging.onMessage.listenが無効になる
-      // await channel.invokeMethod('triggerNotification');
-    } else {
-      NativeSound.playDefaultNotificationSound();
-    }
-
-    if (message.notification != null) {
-      print('Message also contained a notification: ${message.notification}');
-    }
-  });
-
   runApp(
-    UncontrolledProviderScope(
-      container: container,
-      child: const MyApp(),
+    const ProviderScope(
+      child: MyApp(),
     ),
   );
 }
@@ -119,6 +92,7 @@ class MyHomePage extends ConsumerStatefulWidget {
 
 class _MyHomePageState extends ConsumerState<MyHomePage> with WidgetsBindingObserver {
   bool isBadgeVisible = false;
+  static const platform = MethodChannel('com.example.app/notifications');
 
   Future<void> setupInteractedMessage() async {
     RemoteMessage? initialMessage =
@@ -129,8 +103,53 @@ class _MyHomePageState extends ConsumerState<MyHomePage> with WidgetsBindingObse
     }
 
     FirebaseMessaging.onMessageOpenedApp.listen(_handleMessage);
+
+    // ④
+    // アプリがフォアグラウンド状態にある場合にメッセージを受け取る処理
+    //
+    FirebaseMessaging.onMessage.listen((RemoteMessage message) async {
+      print('(ANDROID)アプリがフォアグラウンド時に通知が届きました。');
+      // print('Message data: ${message.data}');
+      await NotificationPreferencesManager.setNewNotifications(ref,true);
+      await NotificationPreferencesManager.setNotificationCountAdd(ref);
+
+      // ⑤
+      // IOSとAndroidの場合で通知音を再生する処理を分ける
+      //
+      NativeSound.playDefaultNotificationSound();
+
+      if (message.notification != null) {
+        print('Message also contained a notification: ${message.notification}');
+      }
+    });
+
+    //
+    // IOS端末がフォアグラウンド時に通知を受け取った際の処理
+    //
+    platform.setMethodCallHandler((MethodCall call) async {
+      switch (call.method) {
+        case 'onMessage':
+          await NotificationPreferencesManager.setNewNotifications(ref, true);
+          await NotificationPreferencesManager.setNotificationCountAdd(ref);
+          final title = call.arguments['title'];
+          final body = call.arguments['body'];
+          print('Got a message from iOS: title: $title, body: $body');
+          print('(IOS)アプリがフォアグラウンド時に通知が届きました。');
+          break;
+        case 'onNotificationTap':
+          final title = call.arguments['title'];
+          final body = call.arguments['body'];
+          print('Notification tapped: title: $title, body: $body');
+          print('(IOS)通知がタップされました。');
+          // タップされた通知の処理を追加
+          break;
+        default:
+          print('Unknown method: ${call.method}');
+      }
+    });
   }
 
+  // これはandroidで動作します。
   void _handleMessage(RemoteMessage message) {
     print("通知がタップされました。");
     // if (message.data['type'] == 'chat') {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:awesome_project01/providers/notification_provider.dart';
 import 'package:awesome_project01/services/notification_preferences_manager.dart';
 import 'package:awesome_project01/utils/native_sound.dart';
@@ -51,11 +53,16 @@ void main() async {
     print('Message data: ${message.data}');
     await NotificationPreferencesManager.setNewNotifications(container,true);
     await NotificationPreferencesManager.setNotificationCountAdd(container);
+    const MethodChannel channel = MethodChannel('com.yourcompany.notifications');
 
     // ⑤
-    // 通知音を再生する
+    // IOSとAndroidの場合で通知音を再生する処理を分ける
     //
-    NativeSound.playDefaultNotificationSound();
+    if (Platform.isIOS) {
+      await channel.invokeMethod('triggerNotification');
+    } else {
+      NativeSound.playDefaultNotificationSound();
+    }
 
     if (message.notification != null) {
       print('Message also contained a notification: ${message.notification}');
@@ -78,11 +85,7 @@ void main() async {
 void setupTokenRefreshListener() {
   FirebaseMessaging.instance.onTokenRefresh.listen((fcmToken) {
     print('新しいFCMトークン: $fcmToken');
-    //  c5H92-5bQiCjjtPdQngjHk:APA91bF9O160F69isR_1GrFL0AoxXEqm36ZdE26LJJnVnRoOPlE8myH9-acfok6IViiBxDY-QlfnKHCHh-xCLi0I9q8YXu0r6QRBjCiIIn7LQfGQeN6Qk2-68t2GEWa0OjKs4
-    // TODO: If necessary send token to application server.
-    //
     // TODO:　ReverpodでFCMトークンを管理し、適切な場面でサーバーへ送信する。
-    //
   }).onError((err) {
     print('新しいFCMトークンの取得に失敗しました。');
   });

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -59,7 +59,8 @@ void main() async {
     // IOSとAndroidの場合で通知音を再生する処理を分ける
     //
     if (Platform.isIOS) {
-      await channel.invokeMethod('triggerNotification');
+      // TODO: IOSローカル通知を受け取った際にFirebaseMessaging.onMessage.listenが無効になる
+      // await channel.invokeMethod('triggerNotification');
     } else {
       NativeSound.playDefaultNotificationSound();
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -168,22 +168,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  http:
-    dependency: "direct main"
-    description:
-      name: http
-      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.13.6"
-  http_parser:
-    dependency: transitive
-    description:
-      name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -461,14 +445,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.0"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.2"
   vector_math:
     dependency: transitive
     description:


### PR DESCRIPTION
## IOS端末の通知処理
<フォアグラウンド時に通知を受け取る処理>
Swiftで設定し受け取る([userNotificationCenter](https://developer.apple.com/documentation/usernotifications/unusernotificationcenterdelegate/usernotificationcenter(_:willpresent:withcompletionhandler:)))→Flutterへ渡す

<通知音を鳴らす処理>

<通知をタップした時の処理>
